### PR TITLE
Fix lint and prisma error handling

### DIFF
--- a/src/app/(dashboard)/templates/page.tsx
+++ b/src/app/(dashboard)/templates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
-import { Linkedin, Twitter, Plus, AlertCircle, RefreshCw } from "lucide-react"
+import { Plus, AlertCircle, RefreshCw } from "lucide-react"
 import { 
   getTemplates, 
   deleteTemplate, 

--- a/src/app/api/test-webhook/route.ts
+++ b/src/app/api/test-webhook/route.ts
@@ -4,7 +4,7 @@ export const config = {
   runtime: 'edge'
 };
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   return NextResponse.json({ status: 'OK', message: 'Webhook endpoint accessible' });
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import {
   ClerkProvider,
   SignedIn,
   SignedOut,
-  RedirectToSignIn,
 } from '@clerk/nextjs';
 
 const inter = Inter({ subsets: ["latin"] });

--- a/src/services/openai.service.ts
+++ b/src/services/openai.service.ts
@@ -93,7 +93,7 @@ Please apply the template instructions and create optimized versions for both Li
     let parsedContent: ProcessedContent;
     try {
       parsedContent = JSON.parse(responseContent);
-    } catch (parseError) {
+    } catch {
       // Fallback: try to extract content if JSON parsing fails
       console.warn('Failed to parse OpenAI response as JSON, attempting fallback extraction');
       throw new Error('Invalid response format from OpenAI');

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/prisma';
-import { Prisma } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 export async function createUser(data: {
   clerkId: string;
@@ -11,7 +11,7 @@ export async function createUser(data: {
       data: data
     });
   } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (error instanceof PrismaClientKnownRequestError) {
       if (error.code === 'P2002') {
         throw new Error(`User with this ${error.meta?.target} already exists`);
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
 }


### PR DESCRIPTION
## Summary
- avoid unused imports in template dashboard page
- drop unused parameter from test webhook route
- remove unused Clerk component
- streamline JSON parse error handling in openai service
- fix Prisma error import in user service
- tweak TypeScript config to exclude .next directory

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68481e10904c8329aac07cdad7201233